### PR TITLE
Fix for PS0

### DIFF
--- a/system/etc/mkshrc
+++ b/system/etc/mkshrc
@@ -96,7 +96,7 @@ else
   PS='#'
 fi
 
-PS1=$'\e[35m┌\e[0m\e[92m$USER@$HOSTNAME\e[0m:\e[34m${PWD:-?}\e[0m\n\e[35m└─\e[0m$PS '
+PS1=$'\e[35m┌\e[0m\e[92m$USER@$HOSTNAME\e[0m:\e[34m${PWD:-?}\e[0m\n\e[35m└─\e[0m$PS0 '
 
 export MKSHRCSYS_INSTALLED="true"
 export TMPDIR="$USR/tmp"


### PR DESCRIPTION
/* 
 * The primary prompt string (PS1) followed by
 * the default home directory defined by "/system/etc/mkshrc": ${PWD:-?} 
 * Example value of $PS1  */ ┌root@localhost:/data/chuser/root/usr/etc/profile.d └─┌$USER@$HOSTNAME:${PWD:-?}
└─$PS1  echo $PS1    
┌$USER@$HOSTNAME:${PWD:-?} └─$PS1    

 /* Value of $PS0 */ 
┌root@localhost:/data/chuser/root/usr/etc/profile.d └─┌$USER@$HOSTNAME:${PWD:-?}
└─$PS1  echo $PS0                                                                                                                                                                                            └─   

/* Fixed and example of interactive shell */
┌root@localhost:/data/chuser/root/usr/etc/profile.d └─┌$USER@$HOSTNAME:${PWD:-?}
└─$PS1  nano /system/etc/mkshrc 
. . . 

yuki@nagato ~ $ adb shell

/* Tested with Termux and adb */  
┌root@localhost:/data/chuser/root/home
└─